### PR TITLE
When using windows Users and groups reference by Sid vs Name.

### DIFF
--- a/manifests/manage.pp
+++ b/manifests/manage.pp
@@ -23,7 +23,7 @@ define win_scheduled_task::manage (
       # https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/security-identifiers
       File {
         owner => 'S-1-5-32-544', # Maps to Administrators
-        group => 'S-1-5-32-545	', # Maps to Users
+        group => 'S-1-5-32-545', # Maps to Users
       }
 
       if ! defined(File["${facts['puppet_vardir']}/scheduledtasks"]) {

--- a/manifests/manage.pp
+++ b/manifests/manage.pp
@@ -18,10 +18,12 @@ define win_scheduled_task::manage (
     }
   }
     default: {
-
+      # The following uses microsoft Security Identifiers vs Group names for language support.
+      # Such as German windows versions.
+      # https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/security-identifiers
       File {
-        owner => 'Administrators',
-        group => 'Users',
+        owner => 'S-1-5-32-544', # Maps to Administrators
+        group => 'S-1-5-32-545	', # Maps to Users
       }
 
       if ! defined(File["${facts['puppet_vardir']}/scheduledtasks"]) {


### PR DESCRIPTION

# Reference for SID's

https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/security-identifiers

## Why is this important. 

It prevents nice errors like the following on Puppet Runs. 

```
change from 'VORDEFINIERT\Administratoren' to 'Administrators' failed: Could not find user Administrators
```